### PR TITLE
Fix avcContext memory leak

### DIFF
--- a/screengen.go
+++ b/screengen.go
@@ -243,6 +243,7 @@ func (g *Generator) ImageWxH(ts int64, width, height int) (image.Image, error) {
 
 // Close closes the internal ffmpeg context.
 func (g *Generator) Close() error {
+	C.avcodec_close(g.avcContext)
 	C.avformat_close_input(&g.avfContext)
 	return nil
 }


### PR DESCRIPTION
When calling avcodec_open2 against an AVCodecContext you must call close even if that context has a reference inside an AVFormatContext that is closed with avformat_close_input.

At least, so it would seem. I can't find good documentation explaining this, but if you write an app using screengen that repeatedly calls `NewGenerator` and then `Close` you'll see the memory leak.